### PR TITLE
Changes PHP's memory_limit to make Composer install working

### DIFF
--- a/provision/020-system-services.sh
+++ b/provision/020-system-services.sh
@@ -140,7 +140,7 @@ sed -i 's/;opcache.memory_consumption=.*/opcache.memory_consumption=512/' /etc/p
 sed -i 's/;opcache.interned_strings_buffer=.*/opcache.interned_strings_buffer=4/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
 sed -i 's/;opcache.max_accelerated_files=.*/opcache.max_accelerated_files=60000/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
 sed -i 's/;opcache.validate_timestamps=.*/opcache.validate_timestamps=1/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
-sed -i 's/memory_limit = .*/memory_limit = 2G/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
+sed -i 's/memory_limit = .*/memory_limit = 4G/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
 sed -i "s|;date.timezone =|date.timezone = ${PROJECT_TIME_ZONE}|" /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
 sed -i 's/max_execution_time = .*/max_execution_time = 1800/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
 sed -i 's/zlib.output_compression = .*/zlib.output_compression = On/' /etc/php/"$PROJECT_PHP_VERSION"/fpm/php.ini
@@ -156,7 +156,7 @@ sed -i 's/;opcache.memory_consumption=.*/opcache.memory_consumption=512/' /etc/p
 sed -i 's/;opcache.interned_strings_buffer=.*/opcache.interned_strings_buffer=4/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
 sed -i 's/;opcache.max_accelerated_files=.*/opcache.max_accelerated_files=60000/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
 sed -i 's/;opcache.validate_timestamps=.*/opcache.validate_timestamps=1/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
-sed -i 's/memory_limit = .*/memory_limit = 2G/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
+sed -i 's/memory_limit = .*/memory_limit = 4G/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
 sed -i "s|;date.timezone =|date.timezone = ${PROJECT_TIME_ZONE}|" /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
 sed -i 's/max_execution_time = .*/max_execution_time = 1800/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini
 sed -i 's/zlib.output_compression = .*/zlib.output_compression = On/' /etc/php/"$PROJECT_PHP_VERSION"/cli/php.ini


### PR DESCRIPTION
Composer install breaks due to PHP's 2G memory limit. I changed it to 4G.